### PR TITLE
Improve Docker image efficiency

### DIFF
--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -3,16 +3,17 @@ LABEL maintainer="nagyesta@gmail.com"
 EXPOSE 8443:8443
 ADD lowkey-vault.jar /lowkey-vault.jar
 RUN microdnf install shadow-utils
-RUN groupadd -r -g 1000 lowkey \
-  && useradd -r -u 1000 -g lowkey -m -d /opt/lowkey -s /bin/bash lowkey
-RUN chown -R lowkey:lowkey "/lowkey-vault.jar"
-RUN chmod 555 "/lowkey-vault.jar"
-RUN mkdir "/import"
-RUN chown -R lowkey:lowkey "/import"
-RUN chmod 755 "/import"
-RUN mkdir "/config"
-RUN chown -R lowkey:lowkey "/config"
-RUN chmod 555 "/config"
+RUN \
+  groupadd -r -g 1000 lowkey && \
+  useradd -r -u 1000 -g lowkey -m -d /opt/lowkey -s /bin/bash lowkey && \
+  chown -R lowkey:lowkey "/lowkey-vault.jar" && \
+  chmod 555 "/lowkey-vault.jar" && \
+  mkdir "/import" && \
+  chown -R lowkey:lowkey "/import" && \
+  chmod 755 "/import" && \
+  mkdir "/config" && \
+  chown -R lowkey:lowkey "/config" && \
+  chmod 555 "/config"
 USER lowkey
 WORKDIR /
 CMD [ "sh", "-c", "ls /" ]


### PR DESCRIPTION
__Issue:__ N/A

### Description
<!-- A short summary of changes -->

According to the `dive` utility, the image efficiency of the current Docker image is only 71%. 130 MB of space is wasted due to the inefficiency of the current Dockerfile.

Because each operation in a Dockerfile is a separate layer, we must try to consolidate steps as much as possible.

Each `chown` and `chmod` step adds **43 megabytes** to the image size! That's 86 MB of wasted space currently.

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

- Build the Dockerfile
- Check that image size has decreased
- Check that image efficiency score is now 99%

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [X] The commit messages use semantic versioning: ```{major}```, ```{minor}``` or ```{patch}```
- [X] The changes are focusing on the issue at hand
- [X] I have maintained or increased test coverage

### Notes

- Another PR is available here: https://github.com/nagyesta/lowkey-vault/pull/837
<!-- Any additional remarks you may have. -->