### PR TITLE
chore: Update to JDK21

### DIFF
--- a/.github/workflows/gradle-ci.yml
+++ b/.github/workflows/gradle-ci.yml
@@ -26,10 +26,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,10 +29,10 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PUBLISH_KEY }}
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@c5195efecf7bdfc987ee8bae7a71cb8b11521c00 # v4.7.1
         with:
-          java-version: '17'
+          java-version: '21'
           distribution: 'temurin'
       - # Add support for more platforms with QEMU (optional)
         # https://github.com/docker/setup-qemu-action

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,9 +76,9 @@ dependencies {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_17
+    sourceCompatibility = JavaVersion.VERSION_21
     toolchain {
-        languageVersion = JavaLanguageVersion.of(17)
+        languageVersion = JavaLanguageVersion.of(21)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Warning: this file is used as build trigger, do not add anything else here!
-lowkeyVault = "3.4.33"
+lowkeyVault = "4.0.0"
 
 [libraries]
 lowkey-vault-app = { module = "com.github.nagyesta.lowkey-vault:lowkey-vault-app", version.ref = "lowkeyVault" }

--- a/src/docker/Dockerfile
+++ b/src/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.16_8-jre-ubi9-minimal
+FROM eclipse-temurin:21.0.8_9-jre-ubi9-minimal
 LABEL maintainer="nagyesta@gmail.com"
 EXPOSE 8443:8443
 COPY lowkey-vault.jar /lowkey-vault.jar


### PR DESCRIPTION
__Issue:__ https://github.com/nagyesta/lowkey-vault/issues/1602

### Description
<!-- A short summary of changes -->

- Migrate Docker base image to JDK 21
- Migrate lowkey-vault version to 4.0.0
- Update build workflows to use JDK 21

### Entry point
<!-- Where should the reviewer start in order to properly understand the PR? -->

-

### Checklists

- [x] I have rebased my branch
- [x] My commit message is meaningful
- [x] The changes are focusing on the issue at hand
- [x] I have maintained or increased test coverage

### Notes

-
<!-- Any additional remarks you may have. -->
